### PR TITLE
Calling smartbind is problematic

### DIFF
--- a/R/speed-insights-package.R
+++ b/R/speed-insights-package.R
@@ -1,6 +1,3 @@
-library(RJSONIO)
-library(gtools)
-
 #' Speed results for 1 URL
 #'
 #' The speedfinder function returns the Google Page Speed Insights test results for a single URL as a dataframe.

--- a/R/speed-insights-package.R
+++ b/R/speed-insights-package.R
@@ -45,7 +45,7 @@ speedfinder2 <- function(url,strategy,key) {
 #' @export
 speedlist <- function(pagelist,strategy,key) {
   list1 <- lapply(pagelist,speedfinder2,strategy,key)
-  suppressWarnings(do.call("smartbind",list1))
+  suppressWarnings(do.call(gtools::smartbind,list1))
   }
 
 


### PR DESCRIPTION
When using the `speedlist()` an error of smarbind existence is thrown, like below

```r 
Error in smartbind(list(id = 1L, responseCode = 200, ruleGroups.SPEED = 64,  : 
  could not find function "smartbind"
```
The problem arises from the fact that the function is not called with the namespace but rather with quoted naming.